### PR TITLE
[FEAT] - 로그인페이지 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "time_letter",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^4.1.3",
         "@prisma/client": "^6.4.1",
         "@tailwindcss/postcss": "^4.0.9",
         "@tanstack/react-query": "^5.67.1",
@@ -620,6 +621,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-4.1.3.tgz",
+      "integrity": "sha512-Jsv6UOWYTrEFJ/01ZrnwVXs7KDvP8XIo115i++5PWvNkNvkrsTfGiLS6w+eJ57CYtUtDQalUWovCZDHFJ8u1VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1353,6 +1366,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.5.tgz",
       "integrity": "sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^4.1.3",
     "@prisma/client": "^6.4.1",
     "@tailwindcss/postcss": "^4.0.9",
     "@tanstack/react-query": "^5.67.1",

--- a/src/app/api/capsular/login/route.ts
+++ b/src/app/api/capsular/login/route.ts
@@ -1,25 +1,36 @@
 import prisma from "@/lib/prisma";
 import { actionDecrypt } from "@/lib/crypto";
+import { NextResponse } from "next/server";
 
 export async function POST(request: Request) {
   const formData = await request.formData();
   const userId = formData.get("userId") as string;
   const password = formData.get("password") as string;
 
-  const checkUser = await prisma.capsuler.findUnique({
-    where: {
-      userId,
-    },
-  });
-  if (!checkUser) {
-    return new Response("Not found", { status: 404 });
+  try {
+    const checkUser = await prisma.capsuler.findUnique({
+      where: {
+        userId,
+      },
+    });
+    if (!checkUser) {
+      throw new Error(
+        "아이디 혹은 비밀번호가 일치하지 않습니다. 다시 확인 바랍니다."
+      );
+    }
+
+    const decryptPassword = await actionDecrypt(checkUser.password);
+    if (password !== decryptPassword) {
+      throw new Error(
+        "아이디 혹은 비밀번호가 일치하지 않습니다. 다시 확인 바랍니다."
+      );
+    }
+    return new Response(JSON.stringify(checkUser), {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    });
+  } catch (error) {
+    const errors = error as Error;
+    return NextResponse.json({ error: errors.message }, { status: 401 });
   }
-  const decryptPassword = await actionDecrypt(checkUser.password);
-  if (password !== decryptPassword) {
-    return new Response("Unauthorized", { status: 401 });
-  }
-  return new Response(JSON.stringify(checkUser), {
-    headers: { "content-type": "application/json" },
-    status: 200,
-  });
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={suitLocalFont.className}>
+      <body className={suitLocalFont.className + " bg-[#F7F7F7]"}>
         <QueryProvider>
           <FirstVisitorProvider>
             <DefaultLayout>{children}</DefaultLayout>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,12 @@
+import LoginContainer from "@/components/login/LoginContainer";
+import React from "react";
+
+const LoginPage = () => {
+  return (
+    <>
+      <LoginContainer />
+    </>
+  );
+};
+
+export default LoginPage;

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const RegisterPage = () => {
+  return <div>RegisterPage</div>;
+};
+
+export default RegisterPage;

--- a/src/components/login/LoginContainer.tsx
+++ b/src/components/login/LoginContainer.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import LoginForm from './LoginForm'
+
+const LoginContainer = () => {
+  return (
+    <section className='w-full h-full bg-white flex flex-col px-5 pb-5 pt-[72px]'>
+      <h1 className='text-header text-center py-10'>내 타임캡슐 확인하기</h1>
+      <LoginForm />
+    </section>
+  )
+}
+
+export default LoginContainer

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import Link from "next/link";
+import React from "react";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+
+interface ILoginInput {
+  userId: string;
+  password: string;
+}
+
+const schema = z.object({
+  userId: z
+    .string()
+    .min(4, "올바른 아이디를 입력해주세요.")
+    .regex(/^[a-zA-Z0-9]+$/, "올바른 아이디를 입력해주세요."),
+  password: z
+    .string()
+    .min(6, "비밀번호는 최소 6자 이상이어야 합니다")
+    .regex(/^[a-zA-Z0-9]+$/, "올바른 비밀번호를 입력해주세요."),
+});
+
+// const LoginInput: React.FC<{
+//   className?: string;
+//   type: string;
+//   placeholder: string;
+// }> = ({ className, type, placeholder }) => {
+//   return (
+//     <input
+//       className={`${className} font-semibold p-6 bg-[#F7F7F7] placeholder:text-[#D2D2D2] text-[#5E5B5B] rounded-[20px] w-full`}
+//       type={type}
+//       placeholder={placeholder}
+//     />
+//   );
+// };
+
+const LoginForm = () => {
+  const {
+    handleSubmit,
+    register,
+    watch,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(schema),
+  });
+  const watchUserId = watch("userId");
+  const watchPassword = watch("password");
+  const onLoginSubmit: SubmitHandler<ILoginInput> = async (data) => {
+    const formData = new FormData();
+    formData.append("userId", data.userId);
+    formData.append("password", data.password);
+    const response = await fetch("/api/capsular/login", {
+      method: "POST",
+      body: formData,
+    });
+    if (response.ok) {
+      const user = await response.json();
+      console.log(user);
+    } else {
+      const getError: { error: string } = await response.json();
+      console.log(getError.error);
+    }
+  };
+  return (
+    <form
+      onSubmit={handleSubmit(onLoginSubmit)}
+      className="flex flex-col items-center flex-1 justify-between"
+    >
+      <legend className="sr-only">로그인 폼</legend>
+      <div className="w-full flex flex-col items-center justify-center gap-2">
+        <label className="w-full flex flex-col items-start justify-center gap-1">
+          <input
+            type="text"
+            className="font-semibold p-6 bg-[#F7F7F7] placeholder:text-[#D2D2D2] text-[#5E5B5B] rounded-[20px] w-full"
+            {...register("userId")}
+            placeholder="아이디 입력"
+          />
+          {errors.userId && (
+            <span className="text-sm text-red-500">
+              {errors.userId.message}
+            </span>
+          )}
+        </label>
+        <label className="w-full flex flex-col items-start justify-center gap-1">
+          <input
+            type="password"
+            className="font-semibold p-6 bg-[#F7F7F7] placeholder:text-[#D2D2D2] text-[#5E5B5B] rounded-[20px] w-full"
+            {...register("password")}
+            placeholder="비밀번호 입력"
+          />
+          {errors.password && (
+            <span className="text-sm text-red-500">
+              {errors.password.message}
+            </span>
+          )}
+        </label>
+      </div>
+      <div className="flex flex-col w-full gap-5 items-center">
+        <Link href="/register" className=" font-semibold text-[#8A8686]">
+          내 타임 캡슐 만들기
+        </Link>
+        <button
+          type="submit"
+          disabled={!watchUserId || !watchPassword}
+          className="w-full py-[22px] disabled:bg-[#F7F7F7] rounded-[20px] disabled:text-[#8A8686] bg-[#FF9225] text-white"
+        >
+          확인
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/src/components/onboarding/OnboardingContainer.tsx
+++ b/src/components/onboarding/OnboardingContainer.tsx
@@ -110,7 +110,7 @@ const OnboardingContainer = ({
 
       {/* 버튼 */}
 
-      {step !== 3 ? (
+      {step !== steps.length - 1 ? (
         <button
           onClick={nextStep}
           type="button"

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { type ReactNode, createContext, useRef, useContext } from "react";
+import { useStore } from "zustand";
+import { type AuthStore, createAuthStore } from "@/stores/AuthStore";
+
+export type AuthStoreApi = ReturnType<typeof createAuthStore>;
+
+export const AuthContext = createContext<AuthStoreApi | null>(null);
+
+export const useAuthStore = <T,>(selector: (store: AuthStore) => T): T => {
+  const authStore = useContext(AuthContext);
+  if (!authStore) {
+    throw new Error(
+      "authStore는 AuthStoreProvider 내부에서만 사용할 수 있습니다."
+    );
+  }
+  return useStore(authStore, selector);
+};
+
+const AuthStoreProvider = ({ children }: { children: ReactNode }) => {
+  const storeRef = useRef<AuthStoreApi>(null);
+  if (!storeRef.current) {
+    storeRef.current = createAuthStore();
+  }
+  return (
+    <AuthContext.Provider value={storeRef.current}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export default AuthStoreProvider;

--- a/src/stores/AuthStore.ts
+++ b/src/stores/AuthStore.ts
@@ -1,0 +1,38 @@
+import { createStore } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface IAuthProps {
+  id: number;
+  nick_name: string;
+  user_id: string;
+  background: string;
+  ribbon: string;
+}
+
+interface IAuthActions {
+  initAuthorization: () => void;
+  setAuthorization: (userData: IAuthProps) => void;
+}
+
+export type AuthStore = IAuthProps & IAuthActions;
+
+export const createAuthStore = (initialState?: IAuthProps) => {
+  const DEFAULT_STATE: IAuthProps = {
+    id: 0,
+    nick_name: "",
+    user_id: "",
+    background: "",
+    ribbon: "",
+  };
+  return createStore<AuthStore>()(
+    persist(
+      (set) => ({
+        ...DEFAULT_STATE,
+        ...initialState,
+        initAuthorization: () => set({ ...DEFAULT_STATE }),
+        setAuthorization: (userData: IAuthProps) => set({ ...userData }),
+      }),
+      { name: "login-user" }
+    )
+  );
+};

--- a/src/stores/FirstVisitorStore.ts
+++ b/src/stores/FirstVisitorStore.ts
@@ -1,19 +1,19 @@
 import { createStore } from "zustand";
 import { persist } from "zustand/middleware";
 
-interface FirstVisitorProps {
+interface IFirstVisitorProps {
   firstVisitor: boolean;
 }
 
-interface FirstVisitorActions {
+interface IFirstVisitorActions {
   initFirstVisitor: (firstVisitor: boolean) => void;
   setFirstVisitor: (firstVisitor: boolean) => void;
 }
 
-export type FirstVisitorStore = FirstVisitorProps & FirstVisitorActions;
+export type FirstVisitorStore = IFirstVisitorProps & IFirstVisitorActions;
 
-export const createFirstVisitorStore = (initialState?: FirstVisitorProps) => {
-  const DEFAULT_STATE: FirstVisitorProps = {
+export const createFirstVisitorStore = (initialState?: IFirstVisitorProps) => {
+  const DEFAULT_STATE: IFirstVisitorProps = {
     firstVisitor: true,
   };
   return createStore<FirstVisitorStore>()(


### PR DESCRIPTION
# [FEAT] - 로그인 페이지 추가

## 작업 내용

- 로그인 페이지 구현중
- 로그인이후 데이터를 저장하기 위한 Store 추가
- API 부분 인증 및 try catch 추가로 에러 핸들링
- 이후 Toastify 추가 및 회원가입 구현으로 로그인 테스트 진행 후 issue close 예정

## 작업 이미지

> 작업 관련 첨부 이미지

## 작업 관련 이슈

- #2 
